### PR TITLE
Expose createDescriptor in WGMMA

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -89,8 +89,8 @@ int64_t getSwizzlingFromLayout(const SharedEncodingAttr &layout,
   return swizzlingByteWidth;
 }
 
-static Value createDescriptor(ConversionPatternRewriter &rewriter, Location loc,
-                              int64_t swizzling, uint32_t stride) {
+Value createDescriptor(ConversionPatternRewriter &rewriter, Location loc,
+                       int64_t swizzling, uint32_t stride) {
   // Create descriptor based on the format described in the spec:
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-warpgroup-level-matrix-shared-memory-layout-matrix-descriptor
   union WGMMADescriptor {


### PR DESCRIPTION
In this PR we are exposing createDescriptor in WGMMA to be reused in the internal sparsity implementation from Google (https://github.com/openxla/xla/blob/main/xla/service/gpu/fusions/triton/xla_triton_sparse_passes.cc#L89-L91)
