### PR TITLE
[DRAFT][s4xbf16] JoinOp vectorization patch

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -154,6 +154,19 @@ struct JoinOpConversion : public ConvertOpToLLVMPattern<JoinOp> {
         unpackLLElements(loc, adaptor.getRhs(), rewriter);
     assert(lhsVals.size() == rhsVals.size());
     SmallVector<Value> joinedVals;
+    if (isa<ElementwiseInlineAsmOp>(op.getLhs().getDefiningOp()) &&
+        resultTy.getElementTypeBitWidth() == 16) {
+      for (int i = 0; i < lhsVals.size(); i += 2) {
+        joinedVals.push_back(lhsVals[i]);
+        joinedVals.push_back(lhsVals[i + 1]);
+        joinedVals.push_back(rhsVals[i]);
+        joinedVals.push_back(rhsVals[i + 1]);
+      }
+      Value ret =
+          packLLElements(loc, typeConverter, joinedVals, rewriter, resultTy);
+      rewriter.replaceOp(op, ret);
+      return success();
+    }
     for (int i = 0; i < lhsVals.size(); i++) {
       joinedVals.push_back(lhsVals[i]);
       joinedVals.push_back(rhsVals[i]);


### PR DESCRIPTION
Do not merge until rebased on upstream Triton up to https://github.com/triton-lang/triton/commit/c1ed673b74e1c9aa69416459a4ae9f4fcf8cc6da

This is 1 of the 2 patches needed to improve int4xbf16 GEMM perf.

This is needed because joinOp by default interleaves every element of the two input matrices. In the case of bf16, this means Triton will extract the 2x bf16 values out of the 32-bit register and re-insert them into a new register. This results in many `mov` instructions before MMA. On certain shapes, this could mean a ~10% perf penalty.

This PR addresses the above by situationally "vectorizing" the interleaving; namely, join every two elements instead of one. This avoids the need to extract values out of registers. Of course, this would also require one to modify the inline_asm logic before the join to produce the correct layout.

cc @gflegar 