### PR TITLE
[DRAFT][s4xbf16] JoinOp vectorization patch (Rebased)

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -169,6 +169,19 @@ struct JoinOpConversion : public ConvertOpToLLVMPattern<JoinOp> {
     assert(lhsVals.size() == rhsVals.size());
     SmallVector<Value> joinedVals;
     joinedVals.resize(lhsVals.size() * 2);
+
+    // Specifically for packed upcasting from 4b to 16b dtypes
+    // numContiguousValues cannot be too large, since the two outputs of
+    // inline_asm contain interleaved values OTOH, if numContiguousValues * 16b
+    // < 32b, then we'll need to rearrange 16b values in 32b registers. Hnece we
+    // set numContiguousValues to 2
+    auto inlineOp =
+        dyn_cast<ElementwiseInlineAsmOp>(op.getLhs().getDefiningOp());
+    if (inlineOp && inlineOp.getPackedElement() == 4 &&
+        dstTy.getElementTypeBitWidth() == 16) {
+      numContiguousValues = 2;
+    }
+
     for (int i = 0; i < lhsVals.size(); i += numContiguousValues) {
       for (int j = 0; j < numContiguousValues; j++) {
         joinedVals[2 * i + j] = lhsVals[i + j];

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -59,7 +59,7 @@ createTargetMachine(llvm::Module *module, std::string proc,
   opt.MCOptions.AsmVerbose = true;
   opt.MCOptions.PreserveAsmComments = true;
   std::unique_ptr<llvm::TargetMachine> machine{target->createTargetMachine(
-      module->getTargetTriple(), proc, features, opt, llvm::Reloc::PIC_,
+      module->getTargetTriple().str(), proc, features, opt, llvm::Reloc::PIC_,
       std::nullopt,
       disableLLVMOpt ? llvm::CodeGenOptLevel::None
                      : llvm::CodeGenOptLevel::Aggressive)};


### PR DESCRIPTION
This is 1 of the 2 patches needed to improve int4xbf16 GEMM perf.

This is needed because joinOp by default interleaves every element of the two input matrices. In the case of bf16, this means Triton will extract the 2x bf16 values out of the 32-bit register and re-insert them into a new register. This results in many mov instructions before MMA. On certain shapes, this could mean a ~10% perf penalty.

This PR addresses the above by situationally "vectorizing" the interleaving; namely, join every two elements instead of one. This avoids the need to extract values out of registers. Of course, this would also require one to modify the inline_asm logic before the join to produce the correct layout.

cc @gflegar @loislo 